### PR TITLE
Fix geom polygon compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sportyR
 Title: Plot Scaled 'ggplot' Representations of Sports Playing Surfaces
-Version: 2.2.0
+Version: 2.2.1
 Authors@R: 
     c(
       person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# sportyR 2.2.1
+
+- facetting in ggplot2 now works as expected (#27, @mrcaseb)
+
 # sportyR 2.2.0
 
 ## Patches/Bug Fixes

--- a/R/plot-helpers.R
+++ b/R/plot-helpers.R
@@ -59,6 +59,7 @@ create_plot_base <- function(plot_background = NULL) {
 #' @return A \code{ggplot2} instance with the feature added to it
 #'
 #' @keywords internal
+#' @importFrom rlang .data
 add_feature <- function(g,
                         x_anchor,
                         y_anchor,
@@ -108,8 +109,8 @@ add_feature <- function(g,
       ggplot2::geom_polygon(
         data = df_1,
         ggplot2::aes(
-          x = x,
-          y = y,
+          x = .data$x,
+          y = .data$y,
           group = group
         ),
         fill = feature_color,
@@ -118,8 +119,8 @@ add_feature <- function(g,
       ggplot2::geom_polygon(
         data = df_2,
         ggplot2::aes(
-          x = x,
-          y = y,
+          x = .data$x,
+          y = .data$y,
           group = group
         ),
         fill = feature_color,
@@ -128,8 +129,8 @@ add_feature <- function(g,
       ggplot2::geom_polygon(
         data = df_3,
         ggplot2::aes(
-          x = x,
-          y = y,
+          x = .data$x,
+          y = .data$y,
           group = group
         ),
         fill = feature_color,
@@ -138,8 +139,8 @@ add_feature <- function(g,
       ggplot2::geom_polygon(
         data = df_4,
         ggplot2::aes(
-          x = x,
-          y = y,
+          x = .data$x,
+          y = .data$y,
           group = group
         ),
         fill = feature_color,
@@ -150,8 +151,8 @@ add_feature <- function(g,
       ggplot2::geom_polygon(
         data = df_1,
         ggplot2::aes(
-          x = x,
-          y = y,
+          x = .data$x,
+          y = .data$y,
           group = group
         ),
         fill = feature_color,
@@ -160,8 +161,8 @@ add_feature <- function(g,
       ggplot2::geom_polygon(
         data = df_2,
         ggplot2::aes(
-          x = x,
-          y = y,
+          x = .data$x,
+          y = .data$y,
           group = group
         ),
         fill = feature_color,
@@ -172,8 +173,8 @@ add_feature <- function(g,
       ggplot2::geom_polygon(
         data = df_1,
         ggplot2::aes(
-          x = x,
-          y = y,
+          x = .data$x,
+          y = .data$y,
           group = group
         ),
         fill = feature_color,
@@ -182,8 +183,8 @@ add_feature <- function(g,
       ggplot2::geom_polygon(
         data = df_4,
         ggplot2::aes(
-          x = x,
-          y = y,
+          x = .data$x,
+          y = .data$y,
           group = group
         ),
         fill = feature_color,
@@ -194,8 +195,8 @@ add_feature <- function(g,
       ggplot2::geom_polygon(
         data = df_1,
         ggplot2::aes(
-          x = x,
-          y = y,
+          x = .data$x,
+          y = .data$y,
           group = group
         ),
         fill = feature_color,

--- a/R/plot-helpers.R
+++ b/R/plot-helpers.R
@@ -106,36 +106,40 @@ add_feature <- function(g,
   if (reflect_x && reflect_y) {
     g <- g +
       ggplot2::geom_polygon(
+        data = df_1,
         ggplot2::aes(
-          x = df_1$x,
-          y = df_1$y,
+          x = x,
+          y = y,
           group = group
         ),
         fill = feature_color,
         color = feature_outline_color
       ) +
       ggplot2::geom_polygon(
+        data = df_2,
         ggplot2::aes(
-          x = df_2$x,
-          y = df_2$y,
+          x = x,
+          y = y,
           group = group
         ),
         fill = feature_color,
         color = feature_outline_color
       ) +
       ggplot2::geom_polygon(
+        data = df_3,
         ggplot2::aes(
-          x = df_3$x,
-          y = df_3$y,
+          x = x,
+          y = y,
           group = group
         ),
         fill = feature_color,
         color = feature_outline_color
       ) +
       ggplot2::geom_polygon(
+        data = df_4,
         ggplot2::aes(
-          x = df_4$x,
-          y = df_4$y,
+          x = x,
+          y = y,
           group = group
         ),
         fill = feature_color,
@@ -144,18 +148,20 @@ add_feature <- function(g,
   } else if (reflect_x && !reflect_y) {
     g <- g +
       ggplot2::geom_polygon(
+        data = df_1,
         ggplot2::aes(
-          x = df_1$x,
-          y = df_1$y,
+          x = x,
+          y = y,
           group = group
         ),
         fill = feature_color,
         color = feature_outline_color
       ) +
       ggplot2::geom_polygon(
+        data = df_2,
         ggplot2::aes(
-          x = df_2$x,
-          y = df_2$y,
+          x = x,
+          y = y,
           group = group
         ),
         fill = feature_color,
@@ -164,18 +170,20 @@ add_feature <- function(g,
   } else if (!reflect_x && reflect_y) {
     g <- g +
       ggplot2::geom_polygon(
+        data = df_1,
         ggplot2::aes(
-          x = df_1$x,
-          y = df_1$y,
+          x = x,
+          y = y,
           group = group
         ),
         fill = feature_color,
         color = feature_outline_color
       ) +
       ggplot2::geom_polygon(
+        data = df_4,
         ggplot2::aes(
-          x = df_4$x,
-          y = df_4$y,
+          x = x,
+          y = y,
           group = group
         ),
         fill = feature_color,
@@ -184,9 +192,10 @@ add_feature <- function(g,
   } else {
     g <- g +
       ggplot2::geom_polygon(
+        data = df_1,
         ggplot2::aes(
-          x = df_1$x,
-          y = df_1$y,
+          x = x,
+          y = y,
           group = group
         ),
         fill = feature_color,


### PR DESCRIPTION
fixes #26 

polygons in `add_feature` were drawn by a call to `geom_polygon` with empty datasets. x and y "aesthetics" were assigned values from actual data frames. This messed up facets because ggplot2 "forgot" the data. 

This PR fixes that problem. I do not know if I introduce new problems so @rossdrucker should test and make sure I don't break anything else. However, the below reprex shows that the bug in #26 is fixed. 

``` r
library(tibble)
library(ggplot2)
library(sportyR)

data <- tibble(x = c(0, 22, -22, 41),
               y = c(50, 25, 85, 41.3),
               group = c("shot", "shot", "goal", "goal"))

geom_hockey("NHL", "ozone", rotation = 90) +
  geom_point(data = data, aes(x = x, y = y, color = group)) +
  facet_wrap(~group)
```

![](https://i.imgur.com/W3CQObX.png)<!-- -->

<sup>Created on 2023-06-09 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>