### PR TITLE
Remove roxygen2 in Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,6 @@ Authors@R:
         comment = c(ORCID = "0000-0002-0688-0235")
       )
     )
-Maintainer: Ross Drucker <ross.a.drucker@gmail.com>
 Description: Create scaled 'ggplot' representations of playing surfaces.
     Playing surfaces are drawn pursuant to rule-book specifications.
     This package should be used as a baseline plot for displaying any type of
@@ -32,7 +31,6 @@ Suggests:
     data.table,
     gganimate,
     testthat (>= 3.0.0),
-    roxygen2,
     knitr,
     rmarkdown,
     curl


### PR DESCRIPTION
Hi roxygen2 is not a runtime dependency. It means you don't need it in Suggests.

You declare your dependency on roxygen2 with the roxygenNote field.

https://roxygen2.r-lib.org/articles/roxygen2.html

See https://r-pkgs.org/man.html for reference too

The Maintainer field is irrelevant too as all info is in Authors@R :)