### PR TITLE
Issue 32: Change to plot titles displaying

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,10 @@
+# sportyR 
+
 # sportyR 2.2.1
 
 - Faceting in `{ggplot2}` now works as expected (#27, @mrcaseb)
 - Fixed link in vignette to point to POSIT, not RStudio
+- Fixed [#32](https://github.com/sportsdataverse/sportyR/issues32) with plot titles not displaying correctly
 
 # sportyR 2.2.0
 

--- a/R/plot-helpers.R
+++ b/R/plot-helpers.R
@@ -19,9 +19,9 @@ create_plot_base <- function(plot_background = NULL) {
   g <- ggplot2::ggplot() +
     ggplot2::theme(
       plot.margin = ggplot2::margin(
-        t = -1,
+        t = 0,
         r = 0,
-        b = -1,
+        b = 0,
         l = 0,
         unit = "cm"
       ),


### PR DESCRIPTION
Updated margins in create_plot_base() so that plot titles will be shown when a display range is provided per #32 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Fixed faceting in `{ggplot2}`.
	- Corrected a link in the vignette.
	- Addressed an issue with plot titles not displaying correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->