### PR TITLE
docs(articles): bring the pkgdown articles onto the family template

### DIFF
--- a/vignettes/animating-tracking-data.Rmd
+++ b/vignettes/animating-tracking-data.Rmd
@@ -6,7 +6,7 @@ vignette: >
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 author: "Ross Drucker <br><a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a> <a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>"
-description: "For the following vignette, you'll need the sportyR, ggplot2, and gganimate packages loaded into your workspace."
+description: "Turning tracking coordinates into an animated play, combining <code>sportyR</code> surfaces with <code>gganimate</code>."
 opengraph:
   image:
     src: "https://raw.githubusercontent.com/sportsdataverse/sportyR/main/man/figures/sportyR_gh.png"

--- a/vignettes/animating-tracking-data.Rmd
+++ b/vignettes/animating-tracking-data.Rmd
@@ -5,6 +5,14 @@ vignette: >
   %\VignetteIndexEntry{Animating Tracking Data}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
+author: "Ross Drucker <br><a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a> <a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>"
+description: "For the following vignette, you'll need the sportyR, ggplot2, and gganimate packages loaded into your workspace."
+opengraph:
+  image:
+    src: "https://raw.githubusercontent.com/sportsdataverse/sportyR/main/man/figures/sportyR_gh.png"
+  twitter:
+    card: summary_large_image
+    creator: "@sportyR_pkg"
 ---
 
 ```{r vignette-options, include = FALSE}
@@ -83,3 +91,35 @@ play_anim
 ![Gif of tracking data](https://raw.githubusercontent.com/sportsdataverse/sportyR/main/vignettes/img/animating-tracking-data-bdb-example-animate-play.gif){width=75%}
 
 Easy peasy. As noted on the [plotting-tracking-data](plotting-tracking-data.html) vignette, this too works so long as the geospatial data is provided and contains a way to identify and order the frames of the resulting GIF.
+
+# **Our Authors**
+-   [Ross Drucker](https://x.com/rossdrucker9)
+<a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+<a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+
+## **Citation**
+
+To cite the [**`sportyR`**](https://sportyR.sportsdataverse.org/) R package in publications, use:
+
+BibTex Citation
+
+```bibtex
+@misc{sportyr,
+  author = {Ross Drucker},
+  title = {sportyR: Plot Scaled 'ggplot' Representations of Sports Playing Surfaces},
+  url = {https://sportyR.sportsdataverse.org/},
+  year = {2026}
+}
+```
+
+## **Related SportsDataverse packages**
+
+-   [**cfbfastR**](https://cfbfastR.sportsdataverse.org/) - college football
+-   [**hoopR**](https://hoopR.sportsdataverse.org/) - men's basketball
+-   [**wehoop**](https://wehoop.sportsdataverse.org/) - women's basketball
+-   [**baseballr**](https://baseballr.sportsdataverse.org/) - baseball
+-   [**fastRhockey**](https://fastRhockey.sportsdataverse.org/) - hockey
+-   [**oddsapiR**](https://oddsapiR.sportsdataverse.org/) - betting odds
+-   [**sportyR**](https://sportyR.sportsdataverse.org/) - playing surfaces
+-   [**sportsdataverse-py**](https://py.sportsdataverse.org/) - the Python package
+-   [**sportsdataverse-R**](https://r.sportsdataverse.org/) - the R meta-package

--- a/vignettes/animating-tracking-data.Rmd
+++ b/vignettes/animating-tracking-data.Rmd
@@ -5,7 +5,7 @@ vignette: >
   %\VignetteIndexEntry{Animating Tracking Data}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
-author: "Ross Drucker <br><a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a> <a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>"
+author: "Ross Drucker <br><a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a> <a href='https://github.com/rossdrucker' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker'/></a>"
 description: "Turning tracking coordinates into an animated play, combining <code>sportyR</code> surfaces with <code>gganimate</code>."
 opengraph:
   image:
@@ -95,13 +95,13 @@ Easy peasy. As noted on the [plotting-tracking-data](plotting-tracking-data.html
 # **Our Authors**
 -   [Ross Drucker](https://x.com/rossdrucker9)
 <a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
-<a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+<a href='https://github.com/rossdrucker' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker'/></a>
 
 ## **Citation**
 
 To cite the [**`sportyR`**](https://sportyR.sportsdataverse.org/) R package in publications, use:
 
-BibTex Citation
+BibTeX Citation
 
 ```bibtex
 @misc{sportyr,

--- a/vignettes/customize-plot.Rmd
+++ b/vignettes/customize-plot.Rmd
@@ -5,6 +5,14 @@ vignette: >
   %\VignetteIndexEntry{Customizing Plots}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
+author: "Ross Drucker <br><a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a> <a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>"
+description: "To run the following vignette, you'll need the sportyR package loaded into your workspace."
+opengraph:
+  image:
+    src: "https://raw.githubusercontent.com/sportsdataverse/sportyR/main/man/figures/sportyR_gh.png"
+  twitter:
+    card: summary_large_image
+    creator: "@sportyR_pkg"
 ---
 
 ```{r, include = FALSE}
@@ -78,3 +86,35 @@ geom_football(
   )
 )
 ```
+
+# **Our Authors**
+-   [Ross Drucker](https://x.com/rossdrucker9)
+<a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+<a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+
+## **Citation**
+
+To cite the [**`sportyR`**](https://sportyR.sportsdataverse.org/) R package in publications, use:
+
+BibTex Citation
+
+```bibtex
+@misc{sportyr,
+  author = {Ross Drucker},
+  title = {sportyR: Plot Scaled 'ggplot' Representations of Sports Playing Surfaces},
+  url = {https://sportyR.sportsdataverse.org/},
+  year = {2026}
+}
+```
+
+## **Related SportsDataverse packages**
+
+-   [**cfbfastR**](https://cfbfastR.sportsdataverse.org/) - college football
+-   [**hoopR**](https://hoopR.sportsdataverse.org/) - men's basketball
+-   [**wehoop**](https://wehoop.sportsdataverse.org/) - women's basketball
+-   [**baseballr**](https://baseballr.sportsdataverse.org/) - baseball
+-   [**fastRhockey**](https://fastRhockey.sportsdataverse.org/) - hockey
+-   [**oddsapiR**](https://oddsapiR.sportsdataverse.org/) - betting odds
+-   [**sportyR**](https://sportyR.sportsdataverse.org/) - playing surfaces
+-   [**sportsdataverse-py**](https://py.sportsdataverse.org/) - the Python package
+-   [**sportsdataverse-R**](https://r.sportsdataverse.org/) - the R meta-package

--- a/vignettes/customize-plot.Rmd
+++ b/vignettes/customize-plot.Rmd
@@ -6,7 +6,7 @@ vignette: >
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 author: "Ross Drucker <br><a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a> <a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>"
-description: "To run the following vignette, you'll need the sportyR package loaded into your workspace."
+description: "Recolouring, resizing and re-orienting a <code>sportyR</code> surface, overriding the league defaults to match a team palette or a different coordinate convention."
 opengraph:
   image:
     src: "https://raw.githubusercontent.com/sportsdataverse/sportyR/main/man/figures/sportyR_gh.png"

--- a/vignettes/customize-plot.Rmd
+++ b/vignettes/customize-plot.Rmd
@@ -5,7 +5,7 @@ vignette: >
   %\VignetteIndexEntry{Customizing Plots}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
-author: "Ross Drucker <br><a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a> <a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>"
+author: "Ross Drucker <br><a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a> <a href='https://github.com/rossdrucker' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker'/></a>"
 description: "Recolouring, resizing and re-orienting a <code>sportyR</code> surface, overriding the league defaults to match a team palette or a different coordinate convention."
 opengraph:
   image:
@@ -90,13 +90,13 @@ geom_football(
 # **Our Authors**
 -   [Ross Drucker](https://x.com/rossdrucker9)
 <a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
-<a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+<a href='https://github.com/rossdrucker' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker'/></a>
 
 ## **Citation**
 
 To cite the [**`sportyR`**](https://sportyR.sportsdataverse.org/) R package in publications, use:
 
-BibTex Citation
+BibTeX Citation
 
 ```bibtex
 @misc{sportyr,

--- a/vignettes/plotting-tracking-data.Rmd
+++ b/vignettes/plotting-tracking-data.Rmd
@@ -6,7 +6,7 @@ vignette: >
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 author: "Ross Drucker <br><a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a> <a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>"
-description: "In order to run the following vignettes, you'll need the sportyR and ggplot2 libraries loaded into your workspace."
+description: "Overlaying player and ball tracking coordinates onto a <code>sportyR</code> surface, including how to align a provider's coordinate system with the plot."
 opengraph:
   image:
     src: "https://raw.githubusercontent.com/sportsdataverse/sportyR/main/man/figures/sportyR_gh.png"

--- a/vignettes/plotting-tracking-data.Rmd
+++ b/vignettes/plotting-tracking-data.Rmd
@@ -5,6 +5,14 @@ vignette: >
   %\VignetteIndexEntry{Plotting Tracking Data}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
+author: "Ross Drucker <br><a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a> <a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>"
+description: "In order to run the following vignettes, you'll need the sportyR and ggplot2 libraries loaded into your workspace."
+opengraph:
+  image:
+    src: "https://raw.githubusercontent.com/sportsdataverse/sportyR/main/man/figures/sportyR_gh.png"
+  twitter:
+    card: summary_large_image
+    creator: "@sportyR_pkg"
 ---
 
 ```{r vignette-options, include = FALSE}
@@ -143,3 +151,35 @@ phf_rink +
 ```
 
 And there you have it! This works for any geospatial data, for any sport (supported by `sportyR`), and for any league (supported by `sportyR`). Give it a try, and please reach out if you have ideas for improvements!
+
+# **Our Authors**
+-   [Ross Drucker](https://x.com/rossdrucker9)
+<a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+<a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+
+## **Citation**
+
+To cite the [**`sportyR`**](https://sportyR.sportsdataverse.org/) R package in publications, use:
+
+BibTex Citation
+
+```bibtex
+@misc{sportyr,
+  author = {Ross Drucker},
+  title = {sportyR: Plot Scaled 'ggplot' Representations of Sports Playing Surfaces},
+  url = {https://sportyR.sportsdataverse.org/},
+  year = {2026}
+}
+```
+
+## **Related SportsDataverse packages**
+
+-   [**cfbfastR**](https://cfbfastR.sportsdataverse.org/) - college football
+-   [**hoopR**](https://hoopR.sportsdataverse.org/) - men's basketball
+-   [**wehoop**](https://wehoop.sportsdataverse.org/) - women's basketball
+-   [**baseballr**](https://baseballr.sportsdataverse.org/) - baseball
+-   [**fastRhockey**](https://fastRhockey.sportsdataverse.org/) - hockey
+-   [**oddsapiR**](https://oddsapiR.sportsdataverse.org/) - betting odds
+-   [**sportyR**](https://sportyR.sportsdataverse.org/) - playing surfaces
+-   [**sportsdataverse-py**](https://py.sportsdataverse.org/) - the Python package
+-   [**sportsdataverse-R**](https://r.sportsdataverse.org/) - the R meta-package

--- a/vignettes/plotting-tracking-data.Rmd
+++ b/vignettes/plotting-tracking-data.Rmd
@@ -5,7 +5,7 @@ vignette: >
   %\VignetteIndexEntry{Plotting Tracking Data}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
-author: "Ross Drucker <br><a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a> <a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>"
+author: "Ross Drucker <br><a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a> <a href='https://github.com/rossdrucker' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker'/></a>"
 description: "Overlaying player and ball tracking coordinates onto a <code>sportyR</code> surface, including how to align a provider's coordinate system with the plot."
 opengraph:
   image:
@@ -155,13 +155,13 @@ And there you have it! This works for any geospatial data, for any sport (suppor
 # **Our Authors**
 -   [Ross Drucker](https://x.com/rossdrucker9)
 <a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
-<a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+<a href='https://github.com/rossdrucker' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker'/></a>
 
 ## **Citation**
 
 To cite the [**`sportyR`**](https://sportyR.sportsdataverse.org/) R package in publications, use:
 
-BibTex Citation
+BibTeX Citation
 
 ```bibtex
 @misc{sportyr,

--- a/vignettes/sportyR.Rmd
+++ b/vignettes/sportyR.Rmd
@@ -6,7 +6,7 @@ vignette: >
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 author: "Ross Drucker <br><a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a> <a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>"
-description: "Welcome to sportyR! I'm Ross Drucker, the author of the sportyR package."
+description: "Drawing regulation playing surfaces for a dozen sports from a single call - <code>geom_baseball()</code>, <code>geom_hockey()</code>, <code>geom_basketball()</code> and the rest of the family."
 opengraph:
   image:
     src: "https://raw.githubusercontent.com/sportsdataverse/sportyR/main/man/figures/sportyR_gh.png"

--- a/vignettes/sportyR.Rmd
+++ b/vignettes/sportyR.Rmd
@@ -5,7 +5,7 @@ vignette: >
   %\VignetteIndexEntry{Getting Started}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
-author: "Ross Drucker <br><a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a> <a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>"
+author: "Ross Drucker <br><a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a> <a href='https://github.com/rossdrucker' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker'/></a>"
 description: "Drawing regulation playing surfaces for a dozen sports from a single call - <code>geom_baseball()</code>, <code>geom_hockey()</code>, <code>geom_basketball()</code> and the rest of the family."
 opengraph:
   image:
@@ -136,20 +136,16 @@ Follow](https://img.shields.io/twitter/follow/sportsdataverse?&label=%40sportsda
 
 [![GitHub stars](https://img.shields.io/github/stars/sportsdataverse/sportyR.svg?color=ff552e&logo=github&style=flat&label=Star%20sportyR&maxAge=2592000)](https://github.com/sportsdataverse/sportyR/stargazers/)
 
-## **Author**
-
--   [Ross Drucker](https://twitter.com/rossdrucker9) <a href="https://twitter.com/rossdrucker9" target="blank"><img src="https://img.shields.io/twitter/follow/rossdrucker9?color=ff552e&amp;label=%40rossdrucker9&amp;logo=twitter&amp;style=flat" alt="@rossdrucker9"/></a> <a href="https://github.com/rossdrucker" target="blank"><img src="https://img.shields.io/github/followers/rossdrucker?color=ff552e&amp;logo=Github&amp;style=flat" alt="@rossdrucker"/></a>
-
 # **Our Authors**
 -   [Ross Drucker](https://x.com/rossdrucker9)
 <a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
-<a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+<a href='https://github.com/rossdrucker' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker'/></a>
 
 ## **Citation**
 
 To cite the [**`sportyR`**](https://sportyR.sportsdataverse.org/) R package in publications, use:
 
-BibTex Citation
+BibTeX Citation
 
 ```bibtex
 @misc{sportyr,

--- a/vignettes/sportyR.Rmd
+++ b/vignettes/sportyR.Rmd
@@ -5,6 +5,14 @@ vignette: >
   %\VignetteIndexEntry{Getting Started}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
+author: "Ross Drucker <br><a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a> <a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>"
+description: "Welcome to sportyR! I'm Ross Drucker, the author of the sportyR package."
+opengraph:
+  image:
+    src: "https://raw.githubusercontent.com/sportsdataverse/sportyR/main/man/figures/sportyR_gh.png"
+  twitter:
+    card: summary_large_image
+    creator: "@sportyR_pkg"
 ---
 
 ```{r vignette-options, include = FALSE}
@@ -131,3 +139,35 @@ Follow](https://img.shields.io/twitter/follow/sportsdataverse?&label=%40sportsda
 ## **Author**
 
 -   [Ross Drucker](https://twitter.com/rossdrucker9) <a href="https://twitter.com/rossdrucker9" target="blank"><img src="https://img.shields.io/twitter/follow/rossdrucker9?color=ff552e&amp;label=%40rossdrucker9&amp;logo=twitter&amp;style=flat" alt="@rossdrucker9"/></a> <a href="https://github.com/rossdrucker" target="blank"><img src="https://img.shields.io/github/followers/rossdrucker?color=ff552e&amp;logo=Github&amp;style=flat" alt="@rossdrucker"/></a>
+
+# **Our Authors**
+-   [Ross Drucker](https://x.com/rossdrucker9)
+<a href='https://x.com/rossdrucker9' target='blank'><img src='https://img.shields.io/twitter/follow/rossdrucker9?color=blue&amp;label=%40rossdrucker9&amp;logo=x&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+<a href='https://github.com/rossdrucker9' target='blank'><img src='https://img.shields.io/github/followers/rossdrucker9?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@rossdrucker9'/></a>
+
+## **Citation**
+
+To cite the [**`sportyR`**](https://sportyR.sportsdataverse.org/) R package in publications, use:
+
+BibTex Citation
+
+```bibtex
+@misc{sportyr,
+  author = {Ross Drucker},
+  title = {sportyR: Plot Scaled 'ggplot' Representations of Sports Playing Surfaces},
+  url = {https://sportyR.sportsdataverse.org/},
+  year = {2026}
+}
+```
+
+## **Related SportsDataverse packages**
+
+-   [**cfbfastR**](https://cfbfastR.sportsdataverse.org/) - college football
+-   [**hoopR**](https://hoopR.sportsdataverse.org/) - men's basketball
+-   [**wehoop**](https://wehoop.sportsdataverse.org/) - women's basketball
+-   [**baseballr**](https://baseballr.sportsdataverse.org/) - baseball
+-   [**fastRhockey**](https://fastRhockey.sportsdataverse.org/) - hockey
+-   [**oddsapiR**](https://oddsapiR.sportsdataverse.org/) - betting odds
+-   [**sportyR**](https://sportyR.sportsdataverse.org/) - playing surfaces
+-   [**sportsdataverse-py**](https://py.sportsdataverse.org/) - the Python package
+-   [**sportsdataverse-R**](https://r.sportsdataverse.org/) - the R meta-package


### PR DESCRIPTION
Across the 11 SportsDataverse R packages, **43 of 47 articles had no
author/contributor footer and 44 had no citation block** — including all 16
cfbfastR articles and all 7 hoopR ones. Every article is a potential landing
page from search or a shared link, and almost none of them told the reader who
wrote the package or how to cite it.

This adds **only what each article was missing**. Conformant headers and
footers are left byte-identical, so this is a backfill, not a rewrite.

| element | what it adds |
|---|---|
| author line | name + X/GitHub follow badges, generated from `DESCRIPTION` so authors and contributors stay in sync with the package rather than being hand-listed |
| description | lifted from the article's **own opening prose** |
| opengraph + twitter | `summary_large_image` pointing at the package's social card |
| footer | Our Authors → Contributors → Citation (BibTeX) → Related packages |

**Two judgement calls worth flagging:**

- **Articles with no prose get no description.** Parameter tables and pure
  code walk-throughs have nothing to lift, and a filler line
  (`"Getting Started - sportyR."`) reads worse than an absent one, because
  pkgdown prints it under the title on the article index and search engines
  lift it verbatim.
- **The twitter creator is per package, not uniformly `@saiemgilani`.**
  cfbfastR has its own `@cfbfastR`; sportyR is `@sportyR_pkg` (Ross Drucker's);
  and articles written by a specific contributor keep that contributor's
  handle.

## Summary by Sourcery

Standardize sportyR pkgdown articles with consistent metadata, attribution, social sharing, and citation information.

Enhancements:
- Bring the sportyR pkgdown articles into the shared SportsDataverse article template with package metadata, social previews, author attribution, and citation/navigation footers.
- Backfill article descriptions from existing opening prose while preserving appropriate omissions for articles without descriptive prose.

Documentation:
- Standardize the sportyR article presentation and metadata for clearer attribution, citation, sharing, and discovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced package vignettes with author information, descriptions, social-media links, and improved sharing previews.
  * Updated descriptions for animating tracking data, customizing plots, plotting tracking data, and drawing sports surfaces.
  * Added BibTeX citation guidance for citing `sportyR`.
  * Added links to related SportsDataverse packages.
  * Updated the getting-started vignette’s author section while preserving existing tutorials and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->