### PR TITLE
docs: add a cheat sheet link and a package citation

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -382,7 +382,7 @@ To cite the `sportyR` R package in publications, use:
 }
 ```
 
-`citation("sportyR")` returns the same entry with the installed version.
+`citation("sportyR")` returns this entry with the installed version number attached.
 
 ### Acknowledgements
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -359,6 +359,31 @@ By regularly reporting issues, making very slight modifications, fixing
 typos, or just helping others navigate their own issues, you're able to
 join the Scout Team!
 
+## Cheat sheet
+
+A printable one-page reference for `sportyR` — every surface function and the
+arguments that shape it — is available as a free PDF:
+
+📄 **[Download the sportyR cheat sheet (PDF)](https://sportsdataverse.org/cheatsheets/sportyR.pdf)**
+
+Light and dark, US Letter landscape. Every SportsDataverse package has one —
+browse them all at **[sportsdataverse.org/cheatsheets](https://sportsdataverse.org/cheatsheets)**.
+
+## Citation
+
+To cite the `sportyR` R package in publications, use:
+
+``` bibtex
+@misc{drucker_sportyR,
+  author = {Ross Drucker},
+  title = {sportyR: Plot Scaled 'ggplot' Representations of Sports Playing Surfaces.},
+  url = {https://sportyR.sportsdataverse.org/},
+  year = {2020}
+}
+```
+
+`citation("sportyR")` returns the same entry with the installed version.
+
 ### Acknowledgements
 
 Much of the underling code structure in `sportyR`, beginning with

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ To cite the `sportyR` R package in publications, use:
 }
 ```
 
-`citation("sportyR")` returns the same entry with the installed version.
+`citation("sportyR")` returns this entry with the installed version number attached.
 
 ### Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -332,6 +332,31 @@ By regularly reporting issues, making very slight modifications, fixing
 typos, or just helping others navigate their own issues, you're able to
 join the Scout Team!
 
+## Cheat sheet
+
+A printable one-page reference for `sportyR` — every surface function and the
+arguments that shape it — is available as a free PDF:
+
+📄 **[Download the sportyR cheat sheet (PDF)](https://sportsdataverse.org/cheatsheets/sportyR.pdf)**
+
+Light and dark, US Letter landscape. Every SportsDataverse package has one —
+browse them all at **[sportsdataverse.org/cheatsheets](https://sportsdataverse.org/cheatsheets)**.
+
+## Citation
+
+To cite the `sportyR` R package in publications, use:
+
+``` bibtex
+@misc{drucker_sportyR,
+  author = {Ross Drucker},
+  title = {sportyR: Plot Scaled 'ggplot' Representations of Sports Playing Surfaces.},
+  url = {https://sportyR.sportsdataverse.org/},
+  year = {2020}
+}
+```
+
+`citation("sportyR")` returns the same entry with the installed version.
+
 ### Acknowledgements
 
 Much of the underling code structure in `sportyR`, beginning with

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -67,6 +67,8 @@ navbar:
       menu:
       - text: SportsDataverse
         href: https://sportsdataverse.org/
+      - text: "Cheat Sheet (PDF)"
+        href: https://sportsdataverse.org/cheatsheets/sportyR.pdf
       - text: --------------------------------
       - text: "R Packages"
       - text: sportsdataverse-R

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,5 +1,8 @@
-## DESCRIPTION carries no Date field, so fall back to the build year.
-year <- if (!is.null(meta$Date)) sub("-.*", "", meta$Date) else format(Sys.Date(), "%Y")
+## The citation year is PINNED to the release year, not derived from the
+## current date. DESCRIPTION has no Date field, so the previous fallback
+## made the same package version cite as a different year every calendar
+## year, and drift from the bibtex block published in README.md.
+year <- 2020
 note <- sprintf("R package version %s", meta$Version)
 
 bibentry(

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,20 @@
+## DESCRIPTION carries no Date field, so fall back to the build year.
+year <- if (!is.null(meta$Date)) sub("-.*", "", meta$Date) else format(Sys.Date(), "%Y")
+note <- sprintf("R package version %s", meta$Version)
+
+bibentry(
+  bibtype  = "Misc",
+  header   = "To cite the sportyR R package in publications, use:",
+  key      = "drucker_sportyR",
+  author   = person("Ross", "Drucker", email = "ross.a.drucker@gmail.com",
+                    comment = c(ORCID = "0000-0002-0688-0235")),
+  title    = "sportyR: Plot Scaled 'ggplot' Representations of Sports Playing Surfaces.",
+  url      = "https://sportyR.sportsdataverse.org/",
+  year     = year,
+  note     = note,
+  textVersion = paste0(
+    "Ross Drucker (", year, "). sportyR: Plot Scaled 'ggplot' Representations ",
+    "of Sports Playing Surfaces. ", note,
+    ". Retrieved from https://sportyR.sportsdataverse.org/"
+  )
+)


### PR DESCRIPTION
Hi Ross — two small documentation gaps in `sportyR`, both additive and neither touching package code.

### 1. The cheat sheet was unreachable from the repo

`sportyR` has a printable one-page cheat sheet published on the SportsDataverse site — [sportsdataverse.org/cheatsheets/sportyR.pdf](https://sportsdataverse.org/cheatsheets/sportyR.pdf) — but nothing in this repo linked to it, so it was effectively undiscoverable for anyone arriving via GitHub or the pkgdown site.

- A `## Cheat sheet` section in `README.Rmd` + `README.md`.
- A `Cheat Sheet (PDF)` entry in the pkgdown **SDV** menu, directly under the existing SportsDataverse link.

Written into **both** README files as static markdown, so a re-knit can't drop it and the two can't drift.

### 2. `citation("sportyR")` had no entry

The package had no `inst/CITATION`, so R fell back to an auto-generated citation. Added one crediting you, carrying the ORCID already in `DESCRIPTION` (`0000-0002-0688-0235`), plus a matching bibtex block in the README.

### Verification

- `inst/CITATION` loads through `readCitationFile()` with the package's real `DESCRIPTION` metadata.
- `_pkgdown.yml` still parses with R's `yaml` (the parser pkgdown uses).
- `inst/CITATION` is not `.Rbuildignore`d, so it ships.

The cheat sheet itself is a hand-built canvas — if the exported surface changes it needs a revision, so the README notes that. Happy to adjust wording or drop either half if you'd rather.

## Summary by Sourcery

Improve sportyR documentation by making the cheat sheet discoverable and providing a package citation entry.

Enhancements:
- Add discoverable links to the sportyR cheat sheet in the README and pkgdown navigation.
- Add package citation metadata and matching README citation guidance for citing sportyR.

Documentation:
- Document the printable sportyR cheat sheet and package citation information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a downloadable sportyR cheat sheet, including light and dark US Letter landscape versions.
  * Added links to browse related SportsDataverse cheat sheets.
  * Added a Cheat Sheet PDF link to the documentation navigation.
  * Added citation guidance with a BibTeX entry and instructions for retrieving the citation from R.
  * Added package citation metadata with author, ORCID, URL, version, and release-year details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->